### PR TITLE
[CA-24] 편지 리스트 불러오기 에러 처리

### DIFF
--- a/back/src/main/java/crappyUnivLife/timeMachineLetter/domain/Letter.java
+++ b/back/src/main/java/crappyUnivLife/timeMachineLetter/domain/Letter.java
@@ -1,5 +1,6 @@
 package crappyUnivLife.timeMachineLetter.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -22,6 +23,7 @@ public class Letter {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
+    @JsonIgnore
     private Member member;
 
     private String password;

--- a/back/src/main/java/crappyUnivLife/timeMachineLetter/repository/LetterRepository.java
+++ b/back/src/main/java/crappyUnivLife/timeMachineLetter/repository/LetterRepository.java
@@ -24,7 +24,7 @@ public class LetterRepository {
     }
 
     public List<Letter> getLetterList(Long memberId) {
-        return em.createQuery("select l from Letter l where l.member.Id = :memberId", Letter.class)
+        return em.createQuery("select l from Letter l join fetch l.member m where m.Id = :memberId", Letter.class)
                 .setParameter("memberId", memberId)
                 .getResultList();
     }

--- a/back/src/main/java/crappyUnivLife/timeMachineLetter/service/LetterService.java
+++ b/back/src/main/java/crappyUnivLife/timeMachineLetter/service/LetterService.java
@@ -27,13 +27,23 @@ public class LetterService {
     private final LetterRepository letterRepository;
     private final PasswordEncoder passwordEncoder;
 
+    @Transactional(readOnly = true)
     public PostListResponse getLetterList(HttpSession session) {
 
-        Member member = memberRepository.findOne((Long) session.getAttribute("userId"));
-        List<Letter> letterList = letterRepository.getLetterList(member.getId());
-        return new PostListResponse(member.getEmail(), letterList);
+        String accessToken = (String)session.getAttribute("accessToken");
+        Long userId = (Long) session.getAttribute("userId");
+
+        if (accessToken != null) {
+            Member member = memberRepository.findOne(userId);
+            List<Letter> letterList = letterRepository.getLetterList(member.getId());
+            return new PostListResponse(member.getEmail(), letterList);
+        } else {
+            // 세션 유효하지 않음.
+            return new PostListResponse(null, null);
+        }
     }
 
+    @Transactional
     public void createLetter(Letter letter, HttpSession session) {
 
         letter.setPassword(passwordEncoder.encode(letter.getPassword()));
@@ -49,6 +59,7 @@ public class LetterService {
         }
     }
 
+    @Transactional
     public Letter readLetter(String hash) {
         Letter letter = letterRepository.findByHash(hash);
         letter.setPassword(null);


### PR DESCRIPTION
- 원인
Json response 시, JPA에서 영속성 오류 발생.

- 해결
@JsonIgnore

- 참고자료
[[[JPA] FetchType.Lazy로 인한 JSON 오류 (InvalidDefinitionException: No serializer found for class)](https://ahndding.tistory.com/m/24)](https://ahndding.tistory.com/m/24)

- error message
1. Resolved [org.springframework.http.converter.HttpMessageNotWritableException: Could not write JSON: failed to lazily initialize a collection of role: crappyUnivLife.timeMachineLetter.domain.Member.letter, could not initialize proxy - no Session; nested exception is com.fasterxml.jackson.databind.JsonMappingException: failed to lazily initialize a collection of role: crappyUnivLife.timeMachineLetter.domain.Member.letter, could not initialize proxy - no Session (through reference chain: crappyUnivLife.timeMachineLetter.dto.PostListResponse["letterList"]->java.util.ArrayList[0]->crappyUnivLife.timeMachineLetter.domain.Letter["member"]->crappyUnivLife.timeMachineLetter.domain.Member["letter"])]