### PR TITLE
[CA-35] 편지 암호 비교 오류 해결

### DIFF
--- a/back/src/main/java/crappyUnivLife/timeMachineLetter/service/LetterService.java
+++ b/back/src/main/java/crappyUnivLife/timeMachineLetter/service/LetterService.java
@@ -88,7 +88,7 @@ public class LetterService {
 
     private void validatePassword(LetterReadResponse letterReadResponse, String requestPassword, String password) {
 
-        if(password.equals(HASH256(requestPassword))) {
+        if(passwordEncoder.matches(requestPassword, password)) {
             letterReadResponse.setIsEncrypted(false);
         } else {
             letterReadResponse.setTitle(null);


### PR DESCRIPTION
다른 암호화 모듈 함수를 사용해서 비교가 안됐습니다.